### PR TITLE
package.json: Fix path to binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "See what has changed after yarn upgrade.",
   "main": "index.js",
   "bin": {
-    "yarn-lock-diff": "bin/yarn-lock-diff.js"
+    "yarn-lock-diff": "bin/yarn-lock-diff"
   },
   "repository": "https://github.com/ksmakey/yarn-lock-diff",
   "author": "ksmakey@gmail.com",


### PR DESCRIPTION
This could probably be simplified further.

Currently get:

```
$ npx -p @ksmakey/yarn-lock-diff yarn-lock-diff
npm ERR! code ENOENT
npm ERR! syscall chmod
npm ERR! path /home/henrik/.npm/_npx/836053/lib/node_modules/@ksmakey/yarn-lock-diff/bin/yarn-lock-diff.js
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, chmod '/home/henrik/.npm/_npx/836053/lib/node_modules/@ksmakey/yarn-lock-diff/bin/yarn-lock-diff.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```